### PR TITLE
fix: Idaho

### DIFF
--- a/urls.yaml
+++ b/urls.yaml
@@ -83,7 +83,7 @@ filter: css:.ftrTable,html2text,strip
 kind: url
 name: Idaho
 url: https://coronavirus.idaho.gov/
-filter: css:.tablepress,html2text,strip
+filter: css:figure.wp-block-image img,strip
 ---
 kind: url
 name: Illinois


### PR DESCRIPTION
Idaho moved away from in-page table. This PR goes off the overview .png (which also links to a Tableau). :woman_shrugging: