### PR TITLE
Fix: VA

### DIFF
--- a/urls.yaml
+++ b/urls.yaml
@@ -260,7 +260,7 @@ name: Virginia
 # https://public.tableau.com/views/VirginiaCOVID-19Dashboard/VirginiaCOVID-19Dashboard?:embed=yes&:display_count=yes&:showVizHome=no&:toolbar=no
 url: https://phantomjscloud.com/api/browser/v2/ak-7r01w-m166n-bm6wx-r4vn0-4m2m9/?request={url:'https://public.tableau.com/views/VirginiaCOVID-19Dashboard/VirginiaCOVID-19Dashboard?:showVizHome=no',renderType:'jpg'}
 # filter: sha1sum
-filter: ocr,clean-new-lines,grepi:+ableau
+filter: ocr,clean-new-lines,grepi:\+ableau
 ---
 kind: url
 name: Vermont

--- a/urls.yaml
+++ b/urls.yaml
@@ -260,7 +260,7 @@ name: Virginia
 # https://public.tableau.com/views/VirginiaCOVID-19Dashboard/VirginiaCOVID-19Dashboard?:embed=yes&:display_count=yes&:showVizHome=no&:toolbar=no
 url: https://phantomjscloud.com/api/browser/v2/ak-7r01w-m166n-bm6wx-r4vn0-4m2m9/?request={url:'https://public.tableau.com/views/VirginiaCOVID-19Dashboard/VirginiaCOVID-19Dashboard?:showVizHome=no',renderType:'jpg'}
 # filter: sha1sum
-filter: ocr,clean-new-lines
+filter: ocr,clean-new-lines,grepi:+ableau
 ---
 kind: url
 name: Vermont


### PR DESCRIPTION
VA's Tableau page has a toolbar a the bottom w/ some symbols that OCR has trouble decoding (it produces inconsistent results). Don't consider that line so we stop constantly flagging the state.

I tried playing around w/ url parameters to get the whole toolbar w/ the logo at the bottom to disappear, but to no avail.