### PR TITLE
Adding a diff workflow, take 2

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,0 +1,54 @@
+# This workflow diffs the output of urlwatch before and after a pull request
+
+name: Diff
+
+# Triggers the workflow pull request events
+on: pull_request
+
+jobs:
+  diff:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    
+    - name: Install dependencies
+      run: |
+        sudo apt install tesseract-ocr
+        python -m pip install --upgrade pip
+        pip install git+https://github.com/COVID19Tracking/urlwatch.git -r https://raw.githubusercontent.com/COVID19Tracking/urlwatch/master/requirements-dev.txt
+    
+    - name: Make output dirs
+      run: mkdir output_base output_pull_request
+
+    - name: Checkout pull request
+      uses: actions/checkout@v2
+      with:
+        path: pull_request
+
+    - name: Checkout base
+      uses: actions/checkout@v2
+      with:
+        path: base
+        ref: ${{ github.event.pull_request.base.ref }}
+    
+    - name: Init cache
+      run: urlwatch --urls=base/urls.yaml
+
+    - name: Diff
+      # This will run against the cache built up in the previous step
+      run: |
+        urlwatch --urls=pull_request/urls.yaml > output_pull_request
+        cat output_pull_request
+
+    - uses: actions/upload-artifact@v1
+      with:
+        name: diff
+        path: output_pull_request
+      
+
+    

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -21,9 +21,6 @@ jobs:
         sudo apt install tesseract-ocr
         python -m pip install --upgrade pip
         pip install git+https://github.com/COVID19Tracking/urlwatch.git -r https://raw.githubusercontent.com/COVID19Tracking/urlwatch/master/requirements-dev.txt
-    
-    - name: Make output dirs
-      run: mkdir output_base output_pull_request
 
     - name: Checkout pull request
       uses: actions/checkout@v2


### PR DESCRIPTION
The workflow diffs the output of urlwatch before and after a pull request by using urlwatch's native cache. My hope is that this will make PRs easier to review. Although there may be unrelated changes in the diff (flaky websites, etc), most changes should be relevant.

The workflow will get triggered on any pull_request event. You can see an example of what this will look like here: https://github.com/smike/covid-tracking/pull/23/checks?check_run_id=558328570.

A previous version of this is available in https://github.com/COVID19Tracking/covid-tracking/pull/34. It doesn't use urlwatch's cache to do the diffing so is needlessly more complicated.