### PR TITLE
fix NY

### DIFF
--- a/urls.yaml
+++ b/urls.yaml
@@ -185,8 +185,8 @@ filter: css:[aria-label*="Test"] title,html2text,strip
 ---
 kind: url
 name: New York
-url: https://coronavirus.health.ny.gov/county-county-breakdown-positive-cases
-filter: css:table,html2text
+url: https://phantomjscloud.com/api/browser/v2/ak-7r01w-m166n-bm6wx-r4vn0-4m2m9/?request={url:'https://covid19tracker.health.ny.gov/views/NYS-COVID19-Tracker/NYSDOHCOVID-19Tracker-Map',renderType:'jpg','requestSettings':{'waitInterval':4000},'renderSettings':{'clipRectangle':{'width':310,'height':85,'left':1400},'viewport':{'width':2048,'height':2048}}}
+filter: ocr,clean-new-lines
 ---
 kind: url
 name: North Carolina


### PR DESCRIPTION
They switched to an unparsable Tableau dashboard, but we can OCR the timestamps in the top right corner