### PR TITLE
separate requirements no longer needed

### DIFF
--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -20,7 +20,7 @@ jobs:
       run: |
         sudo apt install tesseract-ocr
         python -m pip install --upgrade pip
-        pip install git+https://github.com/COVID19Tracking/urlwatch.git -r https://raw.githubusercontent.com/COVID19Tracking/urlwatch/master/requirements-dev.txt
+        pip install git+https://github.com/COVID19Tracking/urlwatch.git
     
     - name: Make output dirs
       run: mkdir output_base output_pull_request

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Tracking state test counts. Posting diff changes every ~30mins to #urlwatch in C
 
 ## Installation
 
-- To install the fork of urlwatch: `pip install git+https://github.com/COVID19Tracking/urlwatch.git -r https://raw.githubusercontent.com/COVID19Tracking/urlwatch/master/requirements-dev.txt`
+- To install the fork of urlwatch: `pip install git+https://github.com/COVID19Tracking/urlwatch.git`
   - You also need the tesseract-ocr package, for which you can find the installation instructions [here](https://tesseract-ocr.github.io/tessdoc/Home.html)
 - For development, you can also check out the `COVID19Tracking/urlwatch` repository and deploy from your local copy with `pip3 install .`
 


### PR DESCRIPTION
updating installation instructions and diff workflow setup after https://github.com/COVID19Tracking/urlwatch/pull/9