### PR TITLE
fix: AZ and VA

### DIFF
--- a/urls.yaml
+++ b/urls.yaml
@@ -19,9 +19,9 @@ filter: css:#contentBody table:contains("Cases"),html2text,strip
 kind: url
 name: Arizona
 # https://www.azdhs.gov/preparedness/epidemiology-disease-control/infectious-disease-epidemiology/index.php#novel-coronavirus-home
-url: https://phantomjscloud.com/api/browser/v2/ak-7r01w-m166n-bm6wx-r4vn0-4m2m9/?request={url:'https://tableau.azdhs.gov/views/UpdatedCOVIDdashboardV2/Story1?:embed=y',renderType:'jpg'}
+url: https://tableau.azdhs.gov/views/UpdatedCOVIDdashboardV2/Story1.png
 # filter: sha1sum
-filter: ocr,clean-new-lines,grepi:Refresh
+filter: ocr,clean-new-lines
 ---
 kind: url
 name: California
@@ -257,9 +257,9 @@ kind: url
 name: Virginia
 # http://www.vdh.virginia.gov/coronavirus/
 # https://public.tableau.com/views/VirginiaCOVID-19Dashboard/VirginiaCOVID-19Dashboard?:embed=yes&:display_count=yes&:showVizHome=no&:toolbar=no
-url: https://phantomjscloud.com/api/browser/v2/ak-7r01w-m166n-bm6wx-r4vn0-4m2m9/?request={url:'https://public.tableau.com/views/VirginiaCOVID-19Dashboard/VirginiaCOVID-19Dashboard?:showVizHome=no',renderType:'jpg'}
+url: https://public.tableau.com/views/VirginiaCOVID-19Dashboard/VirginiaCOVID-19Dashboard.png?:showVizHome=no
 # filter: sha1sum
-filter: ocr,clean-new-lines,grepi:\+ableau
+filter: ocr,clean-new-lines
 ---
 kind: url
 name: Vermont


### PR DESCRIPTION
use server-generated image of tableau dashboards instead of relying on phantomjscloud. In my testing this image produces more consistent OCR results.

Unfortunately NY hasn't enabled this feature on their dashboard :-(