### PR TITLE
Fix HI Filter

### DIFF
--- a/urls.yaml
+++ b/urls.yaml
@@ -72,7 +72,7 @@ filter: css:table table:contains("Commercial Lab"),html2text,strip
 kind: url
 name: Hawaii
 url: https://health.hawaii.gov/coronavirusdisease2019/what-you-should-know/current-situation-in-hawaii/
-filter: css:table:contains("Novel Coronavirus in Hawaii"),html2text,strip
+filter: css:table:contains("Total Cases"),html2text,strip
 ---
 kind: url
 name: Iowa


### PR DESCRIPTION
The filter for HI is broken -- looks for text no longer on the page. Updated to something that's still there

Testing:
```
$ urlwatch --urls urls.yaml --test-filter 12
Total Cases
574 (21 newly reported)
Released from Isolation†
410
Required Hospitalization
51
Deaths
9
HAWAII COUNTY
Total Cases
61 total
Released from Isolation†
33
Required Hospitalization
0
Deaths
0
HONOLULU COUNTY
Total Cases
382 total
Released from Isolation†
309
Required Hospitalization
43
Deaths
6
KAUAI COUNTY
Total Cases
21 total
Released from Isolation†
16
Required Hospitalization
1
Deaths
0
MAUI COUNTY
Total Cases
104 total
Released from Isolation†
52
Required Hospitalization
7
Deaths
3
```