### PR TITLE
[CO] Update filter to get all numeric values

### DIFF
--- a/urls.yaml
+++ b/urls.yaml
@@ -38,7 +38,7 @@ filter: css:table:contains("State Officials Announce") tr:nth-child(1),html2text
 kind: url
 name: Colorado
 url: https://covid19.colorado.gov/data
-filter: css:div.field,css:h4,html2text,strip
+filter: css:article .paragraph--type--bp-columns__3col,html2text,strip
 ---
 kind: url
 name: Connecticut

--- a/urls.yaml
+++ b/urls.yaml
@@ -38,7 +38,7 @@ filter: css:table:contains("State Officials Announce") tr:nth-child(1),html2text
 kind: url
 name: Colorado
 url: https://covid19.colorado.gov/data
-filter: css:p:contains("Case Summary") ~ p,html2text,strip
+filter: css:div.field,css:h4,html2text,strip
 ---
 kind: url
 name: Connecticut


### PR DESCRIPTION
The current filter on the site (22-Apr-2020) for CO catches only titles, update to fetch numbers

Testing:
```
# Before:
$ urlwatch --urls urls.yaml --test-filter 6
Learn more about our data
View our outbreak data


# After
$ urlwatch --urls urls.yaml --test-filter 6
10,878
2,123
56
50,645
123
508
10,878
2,123
56
50,645
123
508

```




(the branch is badly named)