### PR TITLE
[PR] update to new PR public page

### DIFF
--- a/urls.yaml
+++ b/urls.yaml
@@ -309,8 +309,8 @@ filter: css:.Blog .post:contains("COVID") .post-content,html2text,strip
 ---
 kind: url
 name: Puerto Rico
-url: https://phantomjscloud.com/api/browser/v2/ak-7r01w-m166n-bm6wx-r4vn0-4m2m9/?request={url:'https://e.infogram.com/dab81851-e3af-4767-b1f5-9b54eb900274',renderType:'html','requestSettings':{'waitInterval':2000}}
-filter: css:div.InfographicEditor-Contents-Item:nth-child(-n+23) div[data-contents="true"],html2text,strip
+url: http://www.salud.gov.pr/Pages/coronavirus.aspx
+filter: css:table:contains("CASOS POS"),html2text,strip
 ---
 kind: url
 name: Virgin Islands


### PR DESCRIPTION
The current link points to an unused dashboard.
Change the link to the main page from dep. of health

# Testing
Original:
```
$ urlwatch --urls urls.yaml --test-filter 55
COVID-19 Dashboard Puerto Rico
Cita sugerida: Instituto de Estadísticas de Puerto Rico.  COVID-19 Dashboard Puerto Rico.  Basado en datos oficiales provistos por el Departamento de Salud de Puerto Rico. Disponible en: https://estadisticas.pr/en/covid-19.
Total de Pruebas Realizadas
Fecha y Hora de esta información (Fecha de Referencia)
Muertes
Cantidad de Casos Positivos (Confirmados)
Edad de los Casos Positivos
1,213
11,332
62
Media (promedio) = No disponible
Mediana = No disponible
Mínimo = No disponible
Máximo = No disponible
19/abril/2020
6:15 AM
Departamento de Salud = No disponible
Sistema de Veteranos = No disponible
Laboratorios privados - No disponible
Departamento de Salud = No disponible
Sistema de Veteranos = No disponible
Laboratorios Privados = No disponible
Registro Demográfico = 21 (33.9%)
Sistema de Vigilancia = 41 (66.1%)
```
After change:
```
$ urlwatch --urls urls.yaml --test-filter 55                                                                                            ​
CASOS POSTIVOS ÚNICOS                                                                                                                                                                       ​
PRUEBA MOLECULAR
            ​PRUEBA SEROLÓGICA
            MUERTES​  ​
            ​1,968
            1,006
            962
            99
```