### PR TITLE
[KY][PR] both page layouts changed, needed to update filter

### DIFF
--- a/urls.yaml
+++ b/urls.yaml
@@ -310,7 +310,7 @@ filter: css:.Blog .post:contains("COVID") .post-content,html2text,strip
 kind: url
 name: Puerto Rico
 url: http://www.salud.gov.pr/Pages/coronavirus.aspx
-filter: css:table:contains("CASOS POS"),html2text,strip
+filter: css:table:contains("POSTIVOS"),html2text,strip
 ---
 kind: url
 name: Virgin Islands

--- a/urls.yaml
+++ b/urls.yaml
@@ -106,7 +106,7 @@ filter: ocr,clean-new-lines,grep:Last updated
 kind: url
 name: Kentucky
 url: https://chfs.ky.gov/agencies/dph/Pages/covid19.aspx
-filter: css:.alert-success,html2text
+filter: css:p:contains("Current as of") + div.row,html2text
 ---
 kind: url
 name: Louisiana


### PR DESCRIPTION
**KY** changed page layout, using the same link and updated the filter to capture the new testing/results section.
**PR** changed the way text is displayed, which broke the filtering, I used a single (unique) word so layout changes should not matter. 


General Q:
If the goal of urlwatch is *just the flag* then the captured data can be smaller -- can always be the "last updated" text on pages that have it. But most filters get the actual numbers (when possible, or photo when numbers are not directly accessible)