### PR TITLE
[NE] update arcgis layer, the current one on longer exists

### DIFF
--- a/urls.yaml
+++ b/urls.yaml
@@ -161,7 +161,7 @@ name: Nebraska
 #url: http://dhhs.ne.gov/Pages/Coronavirus.aspx
 #filter: css:h2:contains("Nebraska Case Information") ~ span:contains("Total number"),html2text,strip
 # this site goes down sometimes but has up-to-date numbers
-url: https://gis.ne.gov/Agency/rest/services/COVID19_County_Layer/MapServer/3/query?f=json&where=NE_JURIS%3D%27yes%27&returnGeometry=false&spatialRel=esriSpatialRelIntersects&outFields=*&outStatistics=%5B%7B%22statisticType%22%3A%22count%22%2C%22onStatisticField%22%3A%22ID%22%2C%22outStatisticFieldName%22%3A%22value%22%7D%5D
+url: https://gis.ne.gov/Agency/rest/services/COVID19_County_Layer/MapServer/1/query?f=json&where=NE_JURIS%3D%27yes%27&returnGeometry=false&spatialRel=esriSpatialRelIntersects&outFields=*&outStatistics=%5B%7B%22statisticType%22%3A%22count%22%2C%22onStatisticField%22%3A%22ID%22%2C%22outStatisticFieldName%22%3A%22value%22%7D%5D
 ---
 kind: url
 name: New Hampshire


### PR DESCRIPTION
Current layer no longer exists, and the query fails, changed it to the updated layer from the dashboard

## Testing
### Before
```
$ urlwatch --urls urls.yaml --test-filter 28
{"error":{"code":400,"extendedCode":-2147216086,"message":"Unable to complete operation.","details":[]}}
```
### After
```
$ urlwatch --urls urls.yaml --test-filter 28
{"displayFieldName":"","fieldAliases":{"value":"value"},"fields":[{"name":"value","type":"esriFieldTypeInteger","alias":"value"}],"features":[{"attributes":{"value":106570}}]}
```