### PR TITLE
[ME][GE] update ME url, and send GE through phantomjscloud

### DIFF
--- a/urls.yaml
+++ b/urls.yaml
@@ -66,9 +66,8 @@ filter: css:.ftrTable,html2text,strip
 kind: url
 name: Georgia
 # https://dph.georgia.gov/covid-19-daily-status-report
-#url: https://phantomjscloud.com/api/browser/v2/ak-7r01w-m166n-bm6wx-r4vn0-4m2m9/?request={url:'https://ga-covid19.ondemand.sas.com/?initialWidth=1360%26childId=covid19dashdph',renderType:'html'}
-url: https://ga-covid19.ondemand.sas.com/report-images/ve1035-375x200.svg
-filter: html2text,strip
+url: https://phantomjscloud.com/api/browser/v2/ak-7r01w-m166n-bm6wx-r4vn0-4m2m9/?request={url:'https://ga-covid19.ondemand.sas.com/',renderType:'html'}
+filter: css:#KPI1,css:div:contains("Testing"),html2text,strip
 ---
 kind: url
 name: Hawaii

--- a/urls.yaml
+++ b/urls.yaml
@@ -126,7 +126,7 @@ filter: css:.ftrTable,html2text,strip
 ---
 kind: url
 name: Maine
-url: https://www.maine.gov/dhhs/mecdc/infectious-disease/epi/airborne/coronavirus.shtml
+url: https://www.maine.gov/dhhs/mecdc/infectious-disease/epi/airborne/coronavirus/data.shtml
 filter: css:table:contains("Data"),html2text
 ---
 kind: url


### PR DESCRIPTION
ME changed their page, this just just a new link for the same structure.

The resource for GE is not existing, and the flag didn't update in 2+ weeks. Strip JS/get the box with testing data.
