### PR TITLE
[VT][ME] Update sources and filters 

### DIFF
--- a/urls.yaml
+++ b/urls.yaml
@@ -126,7 +126,7 @@ filter: css:.ftrTable,html2text,strip
 kind: url
 name: Maine
 url: https://www.maine.gov/dhhs/mecdc/infectious-disease/epi/airborne/coronavirus/data.shtml
-filter: css:table:contains("Data"),html2text
+filter: css:table:contains("All Reported COVID-19 Tests in Maine"),html2text
 ---
 kind: url
 name: Michigan

--- a/urls.yaml
+++ b/urls.yaml
@@ -266,7 +266,7 @@ filter: ocr,clean-new-lines
 ---
 kind: url
 name: Vermont
-url: https://services1.arcgis.com/BkFxaEFNwHqX3tAw/arcgis/rest/services/county_summary/FeatureServer/0/query?where=1%3D1&outFields=*&cacheHint=true&orderByFields=date+DESC&resultRecordCount=1&f=html
+url: https://services1.arcgis.com/BkFxaEFNwHqX3tAw/ArcGIS/rest/services/VIEW_EPI_DailyCount_PUBLIC/FeatureServer/0/query?resultRecordCount=1&orderByFields=date+DESC&outFields=%2A&where=1%3D1
 filter: css:.ftrTable,html2text,strip
 ---
 kind: url


### PR DESCRIPTION
VT: changed their source yesterday, updating to the new ArcGIS Layer
ME: the page url is the same, but they removed the top table we've been using (positives/death), the testing table is still on the page, filtering for it instead