### PR TITLE
[MI] better state source

### DIFF
--- a/urls.yaml
+++ b/urls.yaml
@@ -129,8 +129,8 @@ filter: css:table:contains("All Reported COVID-19 Tests in Maine"),html2text
 ---
 kind: url
 name: Michigan
-url: https://www.michigan.gov/coronavirus/0,9753,7-406-98163-520743--,00.html
-filter: css:table,html2text,strip
+url: https://www.michigan.gov/coronavirus/
+filter: css:section.stat-container,html2text,strip
 ---
 kind: url
 name: Minnesota


### PR DESCRIPTION
The main Coronavirus page updates daily with a short stats box.
The existing page is where data used to be, but with the new PowerBI dashboard it's no longer updated frequently (at all?)

New source:
```sh
$ urlwatch --urls urls.yaml --test-filter 23
Total Confirmed Cases
65,876
Total COVID-19 Deaths
5,972
Daily Confirmed Cases
343
Daily COVID-19 Deaths
0
Updated 7/5/2020
See Cumulative Data
```