### PR TITLE
[AS] calculates SHA-1 checksum of COVID declaration

### DIFF
--- a/urls.yaml
+++ b/urls.yaml
@@ -283,8 +283,8 @@ filter: css:.et_pb_text_inner:contains("Wyoming Updates"),html2text
 ---
 kind: url
 name: American Samoa
-url: https://www.americansamoa.gov/covid-19-advisories
-filter: css:main div[id$="Containerc29iz"],html2text,strip
+url: https://4307e575-0744-4fa0-bcca-68011612de53.filesusr.com/ugd/4bfff9_209244296662496c949e0f42d4749b57.pdf
+filter: sha1sum
 ---
 kind: url
 name: Commonwealth of the Northern Mariana Islands


### PR DESCRIPTION
AS website redesigned (old advisories page gone), so I'm using the linked COVID declaration from the page. 